### PR TITLE
Nest.land

### DIFF
--- a/.github/workflows/publish-to-nest.land.yml
+++ b/.github/workflows/publish-to-nest.land.yml
@@ -1,0 +1,23 @@
+name: "publish current release to nest.land"
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  publishToNestDotLand:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup repo
+        uses: actions/checkout@v2
+
+      - name: "setup" # check: https://github.com/actions/virtual-environments/issues/1777
+        uses: denolib/setup-deno@v2 
+        with:
+         deno-version: v1.4.6
+
+      - name: "check nest.land"
+        run: | 
+          deno run --allow-net --allow-read --allow-run https://deno.land/x/cicd/publish-on-nest.land.ts ${{ secrets.GITHUB_TOKEN }} ${{ secrets.NESTAPIKEY }} ${{ github.repository }}

--- a/egg.json
+++ b/egg.json
@@ -1,0 +1,11 @@
+{
+  "name": "countries",
+  "description": "🦕 module which provides information about countries on earth + mars",
+  "homepage": "https://github.com/michael-spengler/countries",
+  "files": [
+    "./**/*.ts",
+    "README.md",
+    "LICENSE"
+  ],
+  "entry": "./mod.ts"
+}


### PR DESCRIPTION
This PR contains necessary information to publish this Deno module additionally to https://nest.land.

Requirement: You'll need to register at https://nest.land/ once to get an API Key and add it into your repositories secrets - named NESTAPIKEY - see screenshot.

![Screen Shot 2020-10-25 at 00 19 20](https://user-images.githubusercontent.com/43786652/97094733-be8fe800-1657-11eb-970f-3177847fa942.png)
